### PR TITLE
Fixes some bugs and adds some features in spatial.calling, and small …

### DIFF
--- a/src/survey/singlecell/io.py
+++ b/src/survey/singlecell/io.py
@@ -809,7 +809,7 @@ def make_mudata(exp_path: Union[str, Path],
     if len(mdatas) == 1:
         mdata = mdatas[0]
     else:
-        mdata = md.concat(mdatas)
+        mdata = concat_mdatas(mdatas)
 
     if return_metrics:
         return mdata, metrics    


### PR DESCRIPTION
…change in singlecell.io

These are changes that arose as a result of running on a larger dataset with multiple different chip types.

1. In spatial.calling, we now accomodate a chipset that has multiple chips with different bctypes by commenting out a check that makes sure all the chips in the provided chipset are observed in each bctype modality. Don't think this check is necessary since everything is done per chip-bctype at this point, but could be wrong?

2. Adding check_thresh to get_fault_bcs, in the event user wants different thresholds for different bctypes to label them as faulty,

3. Fixed major bug in get_adj, which was previously using the dimension of the array to create the adj array instead of the number of barcodes. This worked for all previous tested chips because htey have been all row-col chips where number of barcodes = number of rows = number of columns, but for V1 chips it broke.

4. Add new feature bctypes to SpatialNormalizer, in case user wants to only normalize bcs of one bctype/modality.

5. Adjust code to report and store 'impossible' barcodes: a combinatorial barcode that is called for a cell but that wasn't in the layout. Warns user, and bcs get stored in the stats of the calling method as 'invalid_combinatorial_barcodes'

6. Make sure top_bcs can't be any larger than the number of bcs of a given bctype (e.g. if there 3 HTOs in the layout, top_bcs=5 will now error)

7. Survey now accepts a chipnums param, which can restrict calling to certain chips. Before the Survey class was implmeneted, this was previously achieved by supplying gb=(chip, [chipnum1, chipnum2]) to add_spatial_calls(), but since call_cells abstracts away the direct call to add_spatial_calls and does all processing per chip beforehand (e.g. compute metrics), it made more sense to just restrict to certain chips in the outer loop. Now, simply call on only the provided chips. For this reason as well, attribute callers is now a dict that gets initialized and updated with additional calls to call_cells.

8. Small change to singlecell.io to use the concat_mdatas function inside make_mudata instead of mdata.concat.